### PR TITLE
Use ES6 imports for crypto-js to reduce bundle size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
-import { lib, SHA256, enc } from "crypto-js";
+import libWordArray from "crypto-js/lib-typedarrays";
+import SHA256 from "crypto-js/sha256";
+import encBase64url from "crypto-js/enc-base64url";
 
 /**
  * Thanks to @SEIAROTg on stackoverflow:
@@ -19,7 +21,7 @@ function toBytesInt32(num: number) {
  * @returns Array of random ints (0 to 255)
  */
 function getRandomValues(size: number) {
-  const randoms = lib.WordArray.random(size);
+  const randoms = libWordArray.random(size);
   const randoms1byte: number[] = [];
 
   randoms.words.forEach((word) => {
@@ -63,7 +65,7 @@ function generateVerifier(length: number): string {
  * @returns The base64 url encoded code challenge
  */
 export function generateChallenge(code_verifier: string) {
-  return SHA256(code_verifier).toString(enc.Base64url);
+  return SHA256(code_verifier).toString(encBase64url);
 }
 
 /** Generate a PKCE challenge pair

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
Hello! 
I use your package in my project and noticed `crypto-js` takes a lot of space in the resulting bundle. I checked that you import the whole `crypto-js` package, but we can significantly reduce the bundle size by importing only the required modules.
I used webpack-bundle-analyzer to check the before and after, around 43 KB can be saved:
<img width="479" alt="image" src="https://user-images.githubusercontent.com/17149511/228373844-bc36834a-254c-45d9-a836-06763370ec6f.png">
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/17149511/228373874-b25a4979-1efc-45b8-abc2-6ce9d7a856b7.png">
