### PR TITLE
Separate entrypoints for node and browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 dist/
 .parcel-cache/
 .vscode/
+src/index.browser.ts
+src/index.node.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,12 @@
       "devDependencies": {
         "@types/jest": "^29.5.0",
         "@types/node": "^18.15.11",
+        "diverge": "^1.0.2",
         "jest": "^29.5.0",
         "typescript": "^5.0.3"
+      },
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1467,9 +1471,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "version": "18.16.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.14.tgz",
+      "integrity": "sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1930,6 +1934,12 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2013,6 +2023,18 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/diverge": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/diverge/-/diverge-1.0.2.tgz",
+      "integrity": "sha512-dVpphhguO8GU/AMDn1Gb3D5vbsoC8bsKQNc8EmOBhLZi2yg17dfDrJ5Jy8xDynU7TljPrSIyrAWooH4phFoQKA==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.8.1"
+      },
+      "bin": {
+        "diverge": "bin/diverge"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -3,15 +3,17 @@
   "version": "4.0.1",
   "description": "Generate or verify a Proof Key for Code Exchange (PKCE) challenge pair",
   "source": "src/index.ts",
-  "main": "dist/index.js",
+  "main": "dist/index.node.js",
+  "browser": "dist/index.browser.js",
   "type": "module",
-  "types": "dist/index.d.ts",
+  "types": "dist/index.node.d.ts",
   "files": [
     "dist/"
   ],
   "scripts": {
     "watch": "tsc --watch --declaration",
-    "build": "tsc --declaration",
+    "preprocess": "env=browser diverge -f src/index.ts src/index.browser.ts && env=node diverge -f src/index.ts src/index.node.ts",
+    "build": "npm run preprocess && tsc --declaration",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "repository": {
@@ -34,6 +36,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.0",
     "@types/node": "^18.15.11",
+    "diverge": "^1.0.2",
     "jest": "^29.5.0",
     "typescript": "^5.0.3"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,15 @@
 import type { webcrypto } from 'node:crypto';
 
-const crypto: webcrypto.Crypto =
+let crypto: webcrypto.Crypto;
+
+// diverge:if env=browser
+crypto = globalThis.crypto; // web browsers
+// diverge:else
+crypto =
   globalThis.crypto?.webcrypto ?? // Node.js 16 REPL has globalThis.crypto as node:crypto
-  globalThis.crypto ?? // web browsers and Node.js 18+ 
+  globalThis.crypto ?? // Node.js 18+ 
   (await import("node:crypto")).webcrypto; // Node.js 16 non-REPL
+// diverge:fi
 
 /**
  * Creates an array of length `size` of random bytes

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,4 +1,4 @@
-import pkceChallenge, { verifyChallenge, generateChallenge } from "../dist/index";
+import pkceChallenge, { verifyChallenge, generateChallenge } from "../dist/index.node";
 
 test("default verifier length is 43", async () => {
   expect((await pkceChallenge()).code_verifier.length).toBe(43);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "skipLibCheck": true,
   },
   "files": [
-    "src/index.ts"
+    "src/index.browser.ts",
+    "src/index.node.ts"
   ]
 }


### PR DESCRIPTION
This is a potential fix for https://github.com/crouchcd/pkce-challenge/issues/24.

By providing separate entrypoints for `"main"` and `"browser"` (https://docs.npmjs.com/cli/v9/configuring-npm/package-json#browser), tools like esbuild can pick the correct file. This avoids including node-specific logic in a browser-specific build.

This is one potential fix to this, using a small tool I found (`diverge`) to generate separate files for browser and node based on a single `index.ts`.

In the future, if the need arises, this also allows specific specific functions that are only available to the browser or node