### PR TITLE
BREAKING CHANGE: Remove Node.js 16 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [18, 20]
 
     steps:
     - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,12 @@
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.0",
-        "@types/node": "^18.15.11",
+        "@types/node": "^20.10.5",
         "jest": "^29.5.0",
         "typescript": "^5.0.3"
+      },
+      "engines": {
+        "node": ">=18.19.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1467,10 +1470,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
-      "dev": true
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -4863,6 +4869,12 @@
       "engines": {
         "node": ">=12.20"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   },
   "homepage": "https://github.com/crouchcd/pkce-challenge#readme",
   "engines": {
-    "node": ">=16.20.0"
+    "node": ">=18.19.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.10.5",
     "jest": "^29.5.0",
     "typescript": "^5.0.3"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
 import type { webcrypto } from 'node:crypto';
 
-const crypto: webcrypto.Crypto =
-  globalThis.crypto?.webcrypto ?? // Node.js 16 REPL has globalThis.crypto as node:crypto
-  globalThis.crypto ?? // web browsers and Node.js 18+ 
-  (await import("node:crypto")).webcrypto; // Node.js 16 non-REPL
+// XXX: @types/node still doesn't have this global variable; declare it explicitly.
+// https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/66675
+declare var crypto: webcrypto.Crypto;
 
 /**
  * Creates an array of length `size` of random bytes


### PR DESCRIPTION
Node.js 16 is not being maintained anymore; we can drop the support. https://nodejs.org/en/blog/announcements/nodejs16-eol

Fixes #24.