### PR TITLE
fix: expose a Workerd-compatible entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "require": "./dist/index.node.d.cts",
         "import": "./dist/index.node.d.ts"
       },
+      "workerd": "./dist/index.browser.js",
       "browser": {
         "types": "./dist/index.browser.d.ts",
         "default": "./dist/index.browser.js"
@@ -17,7 +18,8 @@
       "node": {
         "import": "./dist/index.node.js",
         "require": "./dist/index.node.cjs"
-      }
+      },
+      "default": "./dist/index.browser.js"
     }
   },
   "files": [

--- a/tests/commonjs.test.cjs
+++ b/tests/commonjs.test.cjs
@@ -1,4 +1,4 @@
-const pkceChallenge = require("../dist/index.node.cjs");
+const pkceChallenge = require("pkce-challenge");
 const { verifyChallenge, generateChallenge } = pkceChallenge;
 
 describe("Environment", () => {

--- a/tests/esm.test.js
+++ b/tests/esm.test.js
@@ -1,7 +1,7 @@
 import pkceChallenge, {
   verifyChallenge,
   generateChallenge,
-} from "../dist/index.node";
+} from "pkce-challenge";
 
 describe("Environment", () => {
   console.log(process.version);

--- a/tests/exports.test.js
+++ b/tests/exports.test.js
@@ -5,14 +5,12 @@ async function resolvedInputs(conditions) {
     stdin: {
       contents: 'import pkceChallenge from "pkce-challenge"; pkceChallenge;',
       resolveDir: process.cwd(),
-      sourcefile: "entry.js",
     },
     bundle: true,
     platform: "neutral",
     conditions,
     write: false,
     metafile: true,
-    logLevel: "silent",
   });
 
   return Object.keys(result.metafile.inputs);

--- a/tests/exports.test.js
+++ b/tests/exports.test.js
@@ -1,0 +1,28 @@
+import { build } from "esbuild";
+
+async function resolvedInputs(conditions) {
+  const result = await build({
+    stdin: {
+      contents: 'import pkceChallenge from "pkce-challenge"; pkceChallenge;',
+      resolveDir: process.cwd(),
+      sourcefile: "entry.js",
+    },
+    bundle: true,
+    platform: "neutral",
+    conditions,
+    write: false,
+    metafile: true,
+    logLevel: "silent",
+  });
+
+  return Object.keys(result.metafile.inputs);
+}
+
+test.each([
+  ["workerd", ["workerd"]],
+  ["default", []],
+])("resolves the %s condition to the Web Crypto build", async (_, conditions) => {
+  await expect(resolvedInputs(conditions)).resolves.toContain(
+    "dist/index.browser.js",
+  );
+});


### PR DESCRIPTION
Exposes the existing Web Crypto build through the `workerd` condition and the standard `default` fallback, so Cloudflare Workers and other non-Node runtimes can resolve the package without consumer-side bundler patches. The previous export map had no target when neither `browser` nor `node` was active.

Node ESM, Node CommonJS, and browser mappings remain unchanged. The Node tests now load the public package specifier, while focused neutral-esbuild coverage verifies both Workerd and generic fallback resolution. `npm run build`, `npm test` (39 tests), `npm run test:bundle`, and `npm pack --dry-run` pass locally.

This establishes the contract on the current 6.x line. `@modelcontextprotocol/sdk@1.29.0` currently requests `pkce-challenge@^5.0.0`, so removing a patched 5.0.1 downstream still requires a compatible backport/release or an SDK dependency-range update.